### PR TITLE
extra HTTP headers to add to each server response (there was no option otherwise)

### DIFF
--- a/include/mgos_http_server.h
+++ b/include/mgos_http_server.h
@@ -68,6 +68,11 @@ void mgos_register_http_endpoint_opt(const char *uri_path,
  * static server (404 will be returned).
  */
 void mgos_http_server_set_document_root(const char *document_root);
+  
+/*
+ * Set extra headres to serve. (e.g cors heeaders)
+ */
+void mgos_http_server_set_extra_headers(const char *extra_headers);
 
 #if defined(__cplusplus)
 }

--- a/src/mgos_http_server.c
+++ b/src/mgos_http_server.c
@@ -385,3 +385,7 @@ struct mg_connection *mgos_get_sys_http_server(void) {
 void mgos_http_server_set_document_root(const char *document_root) {
   s_http_server_opts.document_root = document_root;
 }
+
+void mgos_http_server_set_extra_headers(const char *extra_headers) {
+  s_http_server_opts.extra_headers = extra_headers;
+}


### PR DESCRIPTION
Example: to enable CORS, call 
mgos_http_server_set_extra_headers("Access-Control-Allow-Origin: *")